### PR TITLE
Notification when an action is to be dropped

### DIFF
--- a/GCUndoManager.h
+++ b/GCUndoManager.h
@@ -29,6 +29,9 @@ typedef enum
 }
 GCUndoTaskCoalescingKind;
 
+extern NSString * const GCUndoManagerWillDropUndoActionNotification;
+extern NSString * const GCUndoManagerWillDropRedoActionNotification;
+extern NSString * const GCUndoManagerActionKey;
 
 @class GCUndoGroup, GCUndoManagerProxy, GCConcreteUndoTask;
 

--- a/GCUndoManager.h
+++ b/GCUndoManager.h
@@ -12,8 +12,6 @@
 // 2011/01/11 - fix to ensure submitting tasks in response to a checkpoint notification is correctly handled
 // 2011/07/08 - added NSUndoManagerDidCloseUndoGroupNotification for 10.7 (Lion) compatibility
 
-#import <Cocoa/Cocoa.h>
-
 // internal undo manager state is one of these constants
 
 typedef enum


### PR DESCRIPTION
Hi Sean,

Thanks for your latest changes. The only difference in my fork now is just revision 50e7189, which posts a notification when actions are about to be dropped because the undo limit has been reached. I'm using it to release some internal data structures in my application when I'm sure they are not going to be needed any more because the possibility of undoing expired. It's helping my housekeeping a good deal, but I don't know if it would be interesting for a generality of users, though.

Thanks!
