### PR TITLE
Use NSUInteger in -[GCUndoGroup perform] to avoid implicit signedness conversion

### DIFF
--- a/GCUndoManager.m
+++ b/GCUndoManager.m
@@ -1328,7 +1328,7 @@
 {
 	// cause the tasks in the group to be executed IN REVERSE ORDER. Subgroups are recursively executed.
 	
-	NSInteger i = [[self tasks] count];
+	NSUInteger i = [[self tasks] count];
 	
 	while( i-- > 0 )
 		[[self taskAtIndex:i] perform];


### PR DESCRIPTION
Probably harmless but avoids an annoying compiler warning. Could be considered fragile but integer overflow should only happen after the while loop is evaluated. Simply casting to NSInteger might be less fragile, considering the unlikeliness that there could be that large a number of tasks, but IMHO, clumsy. If the integer overflow is too much of a code smell, the alternative would be casting.
